### PR TITLE
Add support for private repos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run LinkChecker
         id: self-check
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,8 @@ jobs:
 
     steps:
       - name: Run LinkChecker
-        uses: paramt/url-checker@master
+        id: self-check
+        uses: ./
         with:
           files: test.md
           blacklist:  https://www.github.com/paramt/this-doesnt-exist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Run LinkChecker
         id: self-check
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test LinkChecker
 
-on: [push]
+on:
+  workflow_dispatch:
+  push:
+
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Check URLs
         uses: paramt/url-checker@master
         with:
@@ -23,5 +25,3 @@ jobs:
 
 ### Sample Output
 [![Example](https://i.imgur.com/35zldHS.png)](https://github.com/paramt/url-checker/commit/093ef6cb5f7e9eff8300887f07eb0c3a55f4aa82/checks)
-
-> Note: url-checker only works on public repositories

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check URLs
         uses: paramt/url-checker@master
         with:

--- a/check_links.py
+++ b/check_links.py
@@ -23,7 +23,7 @@ def get_test_from_file(file):
         with open('./' + file) as f:
             text = f.readlines()
             print("Found file in the locally checked out repo")
-            return text
+            return ' '.join(text)
     except FileNotFoundError as e:
         print("Could not find file checked out locally, falling back to using public link")
 

--- a/check_links.py
+++ b/check_links.py
@@ -16,10 +16,28 @@ exit_status = 0
 def remove_duplicates(urls):
     return list(set(urls))
 
+
+def get_test_from_file(file):
+    # Assume the local file has been checked out in the action
+    try:
+        with open('./' + file) as f:
+            text = f.readlines()
+    except FileNotFoundError as e:
+        print("Could not find file checked out locally, falling back to using public link")
+
+    # Fall-back to pulling from the public URL for backawards comaptibility
+    try:
+        filepath = "https://raw.githubusercontent.com/" + repo + "/master/" + file
+        r = requests.get(filepath)
+        r.raise_for_status()
+        return r.text
+    except requests.exceptions.HTTPError as err:
+        print("Could not find file using fallback public link")    
+
+
 for file in files:
-    print(f"Collecting URLs from {file}")
-    filepath = "https://raw.githubusercontent.com/" + repo + "/master/" + file
-    text = requests.get(filepath).text
+    
+    text = get_test_from_file(file)
 
     extractor = URLExtract()
     file_links = extractor.find_urls(text)

--- a/check_links.py
+++ b/check_links.py
@@ -22,8 +22,8 @@ def get_test_from_file(file):
     try:
         with open('./' + file) as f:
             text = f.readlines()
-        print("Found file in the locally checked out repo")
-        return text
+            print("Found file in the locally checked out repo")
+            return text
     except FileNotFoundError as e:
         print("Could not find file checked out locally, falling back to using public link")
 

--- a/check_links.py
+++ b/check_links.py
@@ -22,6 +22,8 @@ def get_test_from_file(file):
     try:
         with open('./' + file) as f:
             text = f.readlines()
+        print("Found file in the locally checked out repo")
+        return text
     except FileNotFoundError as e:
         print("Could not find file checked out locally, falling back to using public link")
 


### PR DESCRIPTION
I've updated the code to work with private repos

The general approach is to checkout the local repo first, then scan the file from the local version. I've updated the readme example to show the local checkout.

It will fallback to using the existing approach of loading the public URL for backwards compatibility.